### PR TITLE
Fix base branch reference in Gitleaks step

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,11 +49,16 @@ jobs:
 
       - name: Secret Detection with Gitleaks
         run: |
-          # Fetch the latest base branch state
-          git fetch origin ${{ github.base_ref }} --depth=100
+          # Use the correct base branch reference
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          echo "Base branch: $BASE_BRANCH"
           
-          # Calculate new commits using merge base
-          BASE_COMMIT=$(git merge-base origin/${{ github.base_ref }} HEAD)
+          # Fetch the base branch with sufficient depth
+          git fetch origin "$BASE_BRANCH" --depth=100
+          
+          # Calculate the common ancestor commit
+          BASE_COMMIT=$(git merge-base "origin/$BASE_BRANCH" HEAD)
+          echo "Base commit: $BASE_COMMIT"
           
           # Scan only new commits in the PR
           gitleaks detect \


### PR DESCRIPTION
### **User description**
Updated the Gitleaks secret detection step to correctly reference the base branch using the pull request event context. This ensures the correct commits are scanned for secrets in pull requests.


___

### **PR Type**
Bug fix


___

### **Description**
- Use correct base branch reference in Gitleaks step

- Define `BASE_BRANCH` from pull_request context

- Fetch base branch with sufficient depth (100)

- Compute and echo the merge-base commit


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cicd.yml</strong><dd><code>Update Gitleaks base branch handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cicd.yml

<li>Replaced <code>${{ github.base_ref }}</code> with <br><code>github.event.pull_request.base.ref</code><br> <li> Added <code>BASE_BRANCH</code> variable and echo statements<br> <li> Fetch origin <code>BASE_BRANCH</code> with <code>--depth=100</code><br> <li> Updated <code>git merge-base</code> call for the correct branch


</details>


  </td>
  <td><a href="https://github.com/0019-KDU/youtube-blog-converter/pull/34/files#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>