### PR TITLE
Improve Gitleaks secret detection for PR and push events

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,23 +49,34 @@ jobs:
 
       - name: Secret Detection with Gitleaks
         run: |
-          # Use the correct base branch reference
-          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-          echo "Base branch: $BASE_BRANCH"
-          
-          # Fetch the base branch with sufficient depth
-          git fetch origin "$BASE_BRANCH" --depth=100
-          
-          # Calculate the common ancestor commit
-          BASE_COMMIT=$(git merge-base "origin/$BASE_BRANCH" HEAD)
-          echo "Base commit: $BASE_COMMIT"
-          
-          # Scan only new commits in the PR
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # PR event - scan new commits in the PR
+            BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+            echo "Scanning PR commits against base branch: $BASE_BRANCH"
+            git fetch origin "$BASE_BRANCH" --depth=100
+            BASE_COMMIT=$(git merge-base "origin/$BASE_BRANCH" HEAD)
+            RANGE="$BASE_COMMIT..HEAD"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            # Push event - scan all commits in this push
+            echo "Scanning push event commits"
+            if [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+              # Normal push with previous history
+              RANGE="${{ github.event.before }}..${{ github.event.after }}"
+            else
+              # Initial push to new branch/repo
+              RANGE="${{ github.event.after }}"
+            fi
+          else
+            echo "Unsupported event type: ${{ github.event_name }}"
+            exit 1
+          fi
+
+          echo "Scanning commit range: $RANGE"
           gitleaks detect \
             --source . \
             --report-format json \
             --report-path gitleaks-report.json \
-            --log-opts "$BASE_COMMIT..HEAD"
+            --log-opts "$RANGE"
 
       - name: Create issue on failure
         if: ${{ failure() }}


### PR DESCRIPTION
### **User description**
Updated the CI workflow to handle both pull_request and push events for Gitleaks secret scanning. The script now determines the correct commit range to scan based on the event type, ensuring accurate detection of new secrets in both PRs and direct pushes.


___

### **PR Type**
Enhancement


___

### **Description**
- Add conditional logic for Gitleaks event types

- Compute commit `RANGE` for pull_request and push

- Update `--log-opts` to use dynamic range

- Exit on unsupported GitHub events


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cicd.yml</strong><dd><code>Add event-based commit range logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cicd.yml

<li>Added <code>if</code> conditional distinguishing <code>pull_request</code> and <code>push</code><br> <li> Fetched base branch and computed merge-base for PRs<br> <li> Derived <code>RANGE</code> using <code>github.event.before</code> and <code>after</code> for pushes<br> <li> Updated <code>gitleaks detect --log-opts</code> to use <code>$RANGE</code>


</details>


  </td>
  <td><a href="https://github.com/0019-KDU/youtube-blog-converter/pull/36/files#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0">+24/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>